### PR TITLE
added npm start script to start the project, now you type 'npm start'…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ $ sudo npm -g install grunt-cli karma bower
 $ npm install
 $ bower install
 $ cp -r bower_components ./vendor
-$ grunt watch
+$ npm start
 ```

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "name": "angularjs-kickoff",
   "version": "0.0.1",
   "homepage": "",
+	"scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+		"start": "grunt watch"
+  },
   "licenses": {
     "type": "GNU",
     "url": ""


### PR DESCRIPTION
… instead of 'grunt watch'